### PR TITLE
Add slf4j-simple to avoid warning when running application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3")
 
+    implementation("org.slf4j:slf4j-api:1.7.36")
+    runtimeOnly("org.slf4j:slf4j-simple:1.7.36")
+
     testImplementation("org.mock-server:mockserver-netty:5.15.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
Prior to this commit the following warning was emitted when running the
application:

    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See https://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

The recommendation [1] to avoid it is to add a provider to the runtime
classpath with slf4j-simple being the simplest option.

[1] https://www.slf4j.org/manual.html
